### PR TITLE
Remove translatesAutoresizingMaskIntoConstraints

### DIFF
--- a/Sources/SwiftAssRenderer/Overlay/AssSubtitlesView+AVPlayerLayer.swift
+++ b/Sources/SwiftAssRenderer/Overlay/AssSubtitlesView+AVPlayerLayer.swift
@@ -35,7 +35,6 @@ public extension AssSubtitlesView {
 private extension AssSubtitlesView {
     func layout(layer: AVPlayerLayer) {
         guard let playerItem = layer.player?.currentItem, !playerItem.presentationSize.isEmpty else { return }
-        translatesAutoresizingMaskIntoConstraints = false
         frame = AVMakeRect(
             aspectRatio: playerItem.presentationSize,
             insideRect: layer.bounds


### PR DESCRIPTION
### Background
`AssSubtitlesView.layout(layer: AVPlayerLayer)` is not using auto-layout, thus `translatesAutoresizingMaskIntoConstraints` is not needed, and can cause issues for the client.